### PR TITLE
fix(html-samples-compatible-build): inlining video-background-transformer for html compatible builds

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -1,7 +1,7 @@
 import { defineConfig } from 'vite'
 import p from './package.json'
 
-const deps = [...Object.keys(p.dependencies), ...Object.keys(p.peerDependencies) ];
+const deps = [...Object.keys(p.peerDependencies) ];
 
 export default defineConfig({
   build: {


### PR DESCRIPTION
Can we do this @palashgo to make uikit addons compatible with html samples ?

Currently we cannot use ui kit addons in HTML samples because HTML module script can't import a module using a relative entry point. We can use the js files inside the dist directly but the dist file for [video background addon](https://cdn.jsdelivr.net/npm/@dytesdk/ui-kit-addons@2.0.0/dist/video-background.js ) has `import m from "@dytesdk/video-background-transformer";` which can't be resolved in plain HTML projects without adding bundler config to resolve such paths.

Current we have multiple entry points therefore iife builds too can't be generated.

Error:
```
multiple entry points are not supported when output formats include "umd" or "iife".
```
Suggested solution:
Remove @dytesdk/video-background-transformer from external dependencies so that it gets rolled up inline.

Issues:
Sooner or later if some other external dependency comes in such as axios, we will have to inline that too.

Alternate approach:
We create packages folders inside it and release all packages individually. @dytesdk/uikit-addons-video-background, @dytesdk/uikit-addons-hand-raise and so on.