### PR TITLE
fix(video-background): fixed issue with background changer on re-init, added webgl dynamic blur support

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -35,19 +35,22 @@
 <!-- ABOUT THE PROJECT -->
 ## About The Project
 
-This repository consists of all the different ways in which you can use Dyte's
-React UI Kit and other packages to its full extent to get the best live
-audio/video experience.
+This [repository](https://github.com/dyte-io/ui-kit-addons) contains all the ui-kit addons available for the Dyte Web SDK.
 
 ## Samples
 
 Here are the list of available samples at the moment.
 
-1. [Custom Controlbar button](./src/custom-controlbar-button/)
-2. [Video Background](./src/video-background/)
-3. [Hand Raise](./src/hand-raise/)
-4. [Participants Tab Action](./src/participants-tab-action/)
-
+1. [Camera Host Control](./src/camera-host-control/)
+2. [Chat Host Control](./src/chat-host-control/)
+3. [Custom Controlbar button](./src/custom-controlbar-button/)
+4. [Hand Raise](./src/hand-raise/)
+5. [Mic Host Control](./src/mic-host-control/)
+6. [Participant Menu Item](./src/participant-menu-item/)
+7. [Participant Tile Menu](./src/participant-tile-menu/)
+8. [Participants Tab Action](./src/participants-tab-action/)
+9. [Participant Tab Toggle](./src/participants-tab-toggle/)
+10. [Video Background](./src/video-background/)
 
 ## Usage
 

--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@
 
                 const videoBackground = new DyteVideoBackground({
                     modes: ["blur", "virtual"],
-                    blurLength: 50, // 0 - 100 for opacity
+                    blurStrength: 50, // 0 - 100 for opacity
                     images: [
                         "https://images.unsplash.com/photo-1487088678257-3a541e6e3922?q=80&w=2874&auto=format&fit=crop&ixlib=rb-4.0.3",
                         "https://images.unsplash.com/photo-1496715976403-7e36dc43f17b?q=80&w=2848&auto=format&fit=crop&ixlib=rb-4.0.3",

--- a/index.html
+++ b/index.html
@@ -7,15 +7,15 @@
             content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0"
         />
         <title>Dyte UI Kit Addons</title>
-        <script src="https://cdn.dyte.in/core/dyte-2.1.2.js"></script>
+        <script src="https://cdn.dyte.in/core/dyte-2.2.0.js"></script>
     </head>
     <body>
         <div id="root">
             <dyte-meeting id="meeting"></dyte-meeting>
         </div>
         <script type="module">
-            import { defineCustomElements } from "https://cdn.jsdelivr.net/npm/@dytesdk/ui-kit@2.0.4/loader/index.es2017.js";
-            import { registerAddons } from "https://cdn.jsdelivr.net/npm/@dytesdk/ui-kit@2.0.4/dist/esm/index.js";
+            import { defineCustomElements } from "https://cdn.jsdelivr.net/npm/@dytesdk/ui-kit@2.1.3/loader/index.es2017.js";
+            import { registerAddons } from "https://cdn.jsdelivr.net/npm/@dytesdk/ui-kit@2.1.3/dist/esm/index.js";
 
             // Import addons
             import DyteVideoBackground from "/src/video-background/index.ts";
@@ -24,13 +24,15 @@
             import ChatHostControl from "/src/chat-host-control/index.ts";
             import MicHostControl from "/src/mic-host-control/index.ts";
             import CameraHostControl from "/src/camera-host-control/index.ts";
+            import ParticipantTileMenu from "/src/participant-tile-menu/index.ts";
 
             defineCustomElements();
 
-            window.onload = async function () {
+            async function dyteSetupMeetingAndAddons(authToken) {
                 const meetingRef = document.getElementById("meeting");
                 const url = new URL(window.location.href);
-                const authToken = url.searchParams.get("authToken") || 'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdJZCI6IjM5MGJmMjc0LTQxMzMtNDI2ZC04NDkxLWVhN2ExYTE5MDQ4YiIsIm1lZXRpbmdJZCI6ImJiYjVkNjM0LTczNjAtNGY4Yi1hNGNjLTRkNDMyOGM3ZDI0NiIsInBhcnRpY2lwYW50SWQiOiJhYWE0NzlhNi1kYmU5LTRhODgtYWY2NC05YzFhZDg1MWQzOGMiLCJwcmVzZXRJZCI6IjJhZWI3Y2RhLWYxNGUtNDVlMC05MDk3LTM1ZWI3ODhjYzZjMiIsImlhdCI6MTcyNTk1MDg2MywiZXhwIjoxNzM0NTkwODYzfQ.rt0uGXwjxBayLlPm5dfSiQ1xFU2WXJdWa682jHWe-W6oZFnZArdQhQUfUt5kswJRthLJmqVU6ptbqL9RIoFr8_c_ALWv_HzrUeb_4nD9nAtezQ0p7JpXQTma_XFNEr7hUGAn36WZfvnAGYURpxA03060hr1KN8wivIhDtdJykGYG6OBXfMqglRyw2VWiW6upOUIWN2SAiZf-IhaZBHUbjeRqwbiP-KMoiaYvLar8epOxJR_n_pujn-jvrrgQJD3UiGghmApsVDYjupOn1hUlrrdFSW-aW9vPpWPfjfBmXbeLIcR_CPRawcevPIa9C9BRMTKkM2vXJTfrm_lY1HNVeA';
+                authToken = authToken || url.searchParams.get("authToken");
+
                 if (!authToken) {
                     alert("Please provide an authToken in the URL");
                     return;
@@ -38,6 +40,7 @@
 
                 const videoBackground = new DyteVideoBackground({
                     modes: ["blur", "virtual"],
+                    blurLength: 50, // 0 - 100 for opacity
                     images: [
                         "https://images.unsplash.com/photo-1487088678257-3a541e6e3922?q=80&w=2874&auto=format&fit=crop&ixlib=rb-4.0.3",
                         "https://images.unsplash.com/photo-1496715976403-7e36dc43f17b?q=80&w=2848&auto=format&fit=crop&ixlib=rb-4.0.3",
@@ -53,10 +56,19 @@
                     position: "start"
                 });
 
+                const participantMenu = new ParticipantTileMenu([{
+                    label: "Custom Toggle",
+                    onClick: (participantId) => {
+                    console.log('Clicked on custom toggle for ', participantId);
+                    }
+                }], 'top-right');
+
                 const meeting = await DyteClient.init({ authToken, modules: {
                     devTools: {
                     logs: true
                 }}});
+                
+                window.meeting = meeting;
 
                 const handRaise = await HandRaise.init({
                     meeting,
@@ -88,12 +100,15 @@
                 });
 
                 const config = await registerAddons(
-                    [chatHostControl, micHostControl, cameraHostControl, videoBackground, tabAction, handRaise],
+                    [handRaise, chatHostControl, micHostControl, cameraHostControl, videoBackground, tabAction, participantMenu],
                     meeting
                 );
                 meetingRef.meeting = meeting;
                 meetingRef.config = config;
-                window.meeting = meeting;
+            };
+            window.dyteSetupMeetingAndAddons = dyteSetupMeetingAndAddons;
+            window.onload = () => {
+                dyteSetupMeetingAndAddons();
             };
         </script>
     </body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.1.4",
       "license": "ISC",
       "dependencies": {
-        "@dytesdk/video-background-transformer": "2.0.4"
+        "@dytesdk/video-background-transformer": "2.0.5"
       },
       "devDependencies": {
         "typescript": "^5.2.2",
@@ -36,9 +36,9 @@
       "peer": true
     },
     "node_modules/@dytesdk/video-background-transformer": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@dytesdk/video-background-transformer/-/video-background-transformer-2.0.4.tgz",
-      "integrity": "sha512-zIEmniYvE3wsS76SiduH+3DbEx5Wci3JVbxkPeJukS/UKKkwCgxAKzUbf2BzDxyjAKdZIzhKnPjha/S4WOAAsw=="
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@dytesdk/video-background-transformer/-/video-background-transformer-2.0.5.tgz",
+      "integrity": "sha512-emC4RlZRLbTUJGgEvS9hQZV9q9sXnhU9kZ8jBZB2UXM2VbCjGDs4uA2Rq0FYoVIPUbX+toR37si1MIZh/k35XQ=="
     },
     "node_modules/@dytesdk/web-core": {
       "version": "2.1.10",

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
   "author": "dyte Inc.",
   "license": "ISC",
   "dependencies": {
-    "@dytesdk/video-background-transformer": "2.0.4"
+    "@dytesdk/video-background-transformer": "2.0.5"
   },
   "main": "index.js",
   "peerDependencies": {

--- a/src/video-background/index.ts
+++ b/src/video-background/index.ts
@@ -10,6 +10,7 @@ export interface VideoBGAddonArgs {
     images?: string[];
     modes?: BackgroundMode[];
     randomCount?: number;
+    /** Blur strength can be any value from 0 to 100 */
     blurStrength?: number;
     selector?: string;
     buttonIcon?: string;

--- a/src/video-background/index.ts
+++ b/src/video-background/index.ts
@@ -10,7 +10,7 @@ export interface VideoBGAddonArgs {
     images?: string[];
     modes?: BackgroundMode[];
     randomCount?: number;
-    blurLength?: number;
+    blurStrength?: number;
     selector?: string;
     buttonIcon?: string;
     segmentationConfig?: Partial<SegmentationConfig>;
@@ -29,13 +29,14 @@ const defaultIcon =
  * const addon = new VideoBGAddon({
  *   images: ['https://example.com/image1.jpg', 'https://example.com/image2.jpg'],
  *   modes: ['blur', 'virtual', 'random'],
- *   randomCount: 8
+ *   randomCount: 8,
+ *   blurStrength: 50, // 0 to 100
  * });
  */
 export default class VideoBGAddon {
     images: string[];
     randomCount: number;
-    blurLength: number;
+    blurStrength: number;
     modes: BackgroundMode[];
     meeting: Meeting | null = null;
     middleware: any;
@@ -53,7 +54,7 @@ export default class VideoBGAddon {
                 ? args.modes
                 : ["blur", "virtual", "random"];
         this.randomCount = args?.randomCount ?? 8;
-        this.blurLength = args?.blurLength ?? 50;
+        this.blurStrength = args?.blurStrength ?? 50;
         this.buttonIcon = args.buttonIcon;
         if (args.selector) {
             this.selector = args.selector;
@@ -175,7 +176,7 @@ export default class VideoBGAddon {
             await meeting.self.setVideoMiddlewareGlobalConfig({ disablePerFrameCanvasRendering: true });
             if (mode === "blur") {
                 this.middleware =
-                    await this.transform.createBackgroundBlurVideoMiddleware(this.blurLength);
+                    await this.transform.createBackgroundBlurVideoMiddleware(this.blurStrength);
                 await this.meeting.self.addVideoMiddleware(this.middleware);
             } else if (mode === "virtual" && image) {
                 const imageURL = this.getImageDataURLFromImage(imageElement);


### PR DESCRIPTION
[WEB-4129](https://linear.app/dyte/issue/WEB-4129)

fixes WEB-4129

1. Fixed the issue where if a meeting gets ended and another get started on the same page, background changer held the reference of transformer of old meeting thus causing failures in picking the desired background.
2. WebGL had a fix blur earlier due to the WebGL pipeline program issues. A lot of customers wanted the ability to increase the blur so that the background is not visible. Fixed the blur pass program to support dynamic blur. Using the version with the fix here in ui-kit-addons.

**WebGL pipeline now supports dynamic blur in range of 0-100. Current blur that used to be in earlier version is equivalent to 10. Now default is 50 to provide more opaque blur as default.**