### PR TITLE
fix(video-background): highlighting selected middleware, exposed methods to add & remove middlewares

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -37,6 +37,8 @@
 
 This [repository](https://github.com/dyte-io/ui-kit-addons) contains all the ui-kit addons available for the Dyte Web SDK.
 
+A comprehensive guide detailing the usage of these ui-kit addons is available [here](https://dyte.io/blog/ui-kit-add-ons/).
+
 ## Samples
 
 Here are the list of available samples at the moment.
@@ -133,6 +135,22 @@ const cameraHostControl = await CameraHostControl.init({
     targetPresets: ['webinar_viewer'],
     addActionInParticipantMenu: true,
 });
+```
+
+Starting v4.0.0, Video Background Addon also has been migrated to the same structure to make it easier to handle state internally.
+
+```tsx
+  const videoBackground = await DyteVideoBackground.init({
+      modes: ["blur", "virtual", "random"],
+      blurStrength: 30, // 0 - 100 for opacity
+      meeting,
+      images: [
+          "https://images.unsplash.com/photo-1487088678257-3a541e6e3922?q=80&w=2874&auto=format&fit=crop&ixlib=rb-4.0.3",
+          "https://images.unsplash.com/photo-1496715976403-7e36dc43f17b?q=80&w=2848&auto=format&fit=crop&ixlib=rb-4.0.3",
+          "https://images.unsplash.com/photo-1600431521340-491eca880813?q=80&w=2938&auto=format&fit=crop&ixlib=rb-4.0.3"
+      ],
+      randomCount: 10,
+  });
 ```
 
 ## About

--- a/Readme.md
+++ b/Readme.md
@@ -153,6 +153,16 @@ Starting v4.0.0, Video Background Addon also has been migrated to the same struc
   });
 ```
 
+you can now apply, replace, or remove a background programmatically.
+
+```tsx
+videoBackground.applyVirtualBackground('https://images.unsplash.com/photo-1600431521340-491eca880813?q=80&w=2938&auto=format&fit=crop&ixlib=rb-4.0.3')
+videoBackground.applyBlurBackground();
+
+// Common for virtual and blur backgrounds.
+videoBackground.removeBackground();
+```
+
 ## About
 
 This project is created & maintained by dyte, Inc. You can find us on Twitter - [@dyte_io](https://twitter.com/dyte_io) or write to us at `dev@dyte.io`.

--- a/index.html
+++ b/index.html
@@ -7,15 +7,15 @@
             content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0"
         />
         <title>Dyte UI Kit Addons</title>
-        <script src="https://cdn.dyte.in/core/dyte-2.3.0.js"></script>
+        <script src="https://cdn.dyte.in/core/dyte-2.4.0.js"></script>
     </head>
     <body>
         <div id="root">
             <dyte-meeting id="meeting"></dyte-meeting>
         </div>
         <script type="module">
-            import { defineCustomElements } from "https://cdn.jsdelivr.net/npm/@dytesdk/ui-kit@2.2.0/loader/index.es2017.js";
-            import { registerAddons } from "https://cdn.jsdelivr.net/npm/@dytesdk/ui-kit@2.2.0/dist/esm/index.js";
+            import { defineCustomElements } from "https://cdn.jsdelivr.net/npm/@dytesdk/ui-kit@2.2.2/loader/index.es2017.js";
+            import { registerAddons } from "https://cdn.jsdelivr.net/npm/@dytesdk/ui-kit@2.2.2/dist/esm/index.js";
 
             // Import addons
             import DyteVideoBackground from "/src/video-background/index.ts";
@@ -28,20 +28,8 @@
 
             defineCustomElements();
 
-            async function dyteSetupMeetingAndAddons(authToken) {
+            async function registerUIKitAddons(meeting){
                 const meetingRef = document.getElementById("meeting");
-                const url = new URL(window.location.href);
-                authToken = authToken || url.searchParams.get("authToken");
-
-                if (!authToken) {
-                    alert("Please provide an authToken in the URL");
-                    return;
-                }
-
-                // clean up existing meeting if any
-                if (meetingRef.meeting) {
-                    await meetingRef.meeting.leave();
-                }
                 const tabAction = new ParticipantsTabAction({
                     onClick: () => {
                         alert("Clicked!");
@@ -56,13 +44,6 @@
                     console.log('Clicked on custom toggle for ', participantId);
                     }
                 }], 'top-right');
-
-                const meeting = await DyteClient.init({ authToken, modules: {
-                    devTools: {
-                    logs: true
-                }}});
-                
-                window.meeting = meeting;
 
                 const handRaise = await HandRaise.init({
                     meeting,
@@ -91,6 +72,8 @@
                     randomCount: 10,
                 });
 
+                window.videoBackground = videoBackground;
+
                 const micHostControl = await MicHostControl.init({
                     meeting,
                     hostPresets: ['webinar_presenter'],
@@ -111,6 +94,38 @@
                 );
                 meetingRef.meeting = meeting;
                 meetingRef.config = config;
+            }
+
+            async function dyteSetupMeetingAndAddons(authToken, cleanupExistingMeetingIfAny=true) {
+                const meetingRef = document.getElementById("meeting");
+                const url = new URL(window.location.href);
+                authToken = authToken || url.searchParams.get("authToken");
+
+                if (!authToken) {
+                    alert("Please provide an authToken in the URL");
+                    return;
+                }
+
+                // clean up existing meeting if any
+                if (cleanupExistingMeetingIfAny && meetingRef.meeting) {
+                    await meetingRef.meeting.leave();
+                }
+
+                const meeting = await DyteClient.init({ authToken, modules: {
+                    devTools: {
+                    logs: true
+                }}});
+                
+                window.meeting = meeting;
+
+                // Breakout rooms logic
+                meeting.connectedMeetings.on('meetingChanged', async (newMeeting) => {
+                    window.meeting = meeting;
+                    registerUIKitAddons(newMeeting);
+                });
+
+                registerUIKitAddons(meeting);
+                
             };
             window.dyteSetupMeetingAndAddons = dyteSetupMeetingAndAddons;
             window.onload = () => {

--- a/index.html
+++ b/index.html
@@ -38,16 +38,10 @@
                     return;
                 }
 
-                const videoBackground = new DyteVideoBackground({
-                    modes: ["blur", "virtual"],
-                    blurStrength: 50, // 0 - 100 for opacity
-                    images: [
-                        "https://images.unsplash.com/photo-1487088678257-3a541e6e3922?q=80&w=2874&auto=format&fit=crop&ixlib=rb-4.0.3",
-                        "https://images.unsplash.com/photo-1496715976403-7e36dc43f17b?q=80&w=2848&auto=format&fit=crop&ixlib=rb-4.0.3",
-                        "https://images.unsplash.com/photo-1600431521340-491eca880813?q=80&w=2938&auto=format&fit=crop&ixlib=rb-4.0.3"
-                    ]
-                });
-
+                // clean up existing meeting if any
+                if (meetingRef.meeting) {
+                    await meetingRef.meeting.leave();
+                }
                 const tabAction = new ParticipantsTabAction({
                     onClick: () => {
                         alert("Clicked!");
@@ -83,6 +77,18 @@
                     targetPresets: ['webinar_viewer'],
                     addActionInParticipantMenu: true,
                     userBlockType: 'TEMPORARY',
+                });
+
+                const videoBackground = await DyteVideoBackground.init({
+                    modes: ["blur", "virtual", "random"],
+                    blurStrength: 30, // 0 - 100 for opacity
+                    meeting,
+                    images: [
+                        "https://images.unsplash.com/photo-1487088678257-3a541e6e3922?q=80&w=2874&auto=format&fit=crop&ixlib=rb-4.0.3",
+                        "https://images.unsplash.com/photo-1496715976403-7e36dc43f17b?q=80&w=2848&auto=format&fit=crop&ixlib=rb-4.0.3",
+                        "https://images.unsplash.com/photo-1600431521340-491eca880813?q=80&w=2938&auto=format&fit=crop&ixlib=rb-4.0.3"
+                    ],
+                    randomCount: 10,
                 });
 
                 const micHostControl = await MicHostControl.init({

--- a/index.html
+++ b/index.html
@@ -7,15 +7,15 @@
             content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0"
         />
         <title>Dyte UI Kit Addons</title>
-        <script src="https://cdn.dyte.in/core/dyte-2.2.0.js"></script>
+        <script src="https://cdn.dyte.in/core/dyte-2.3.0.js"></script>
     </head>
     <body>
         <div id="root">
             <dyte-meeting id="meeting"></dyte-meeting>
         </div>
         <script type="module">
-            import { defineCustomElements } from "https://cdn.jsdelivr.net/npm/@dytesdk/ui-kit@2.1.3/loader/index.es2017.js";
-            import { registerAddons } from "https://cdn.jsdelivr.net/npm/@dytesdk/ui-kit@2.1.3/dist/esm/index.js";
+            import { defineCustomElements } from "https://cdn.jsdelivr.net/npm/@dytesdk/ui-kit@2.2.0/loader/index.es2017.js";
+            import { registerAddons } from "https://cdn.jsdelivr.net/npm/@dytesdk/ui-kit@2.2.0/dist/esm/index.js";
 
             // Import addons
             import DyteVideoBackground from "/src/video-background/index.ts";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dytesdk/ui-kit-addons",
-  "version": "3.1.8",
+  "version": "4.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dytesdk/ui-kit-addons",
-      "version": "3.1.8",
+      "version": "4.0.0",
       "license": "ISC",
       "dependencies": {
         "@dytesdk/video-background-transformer": "2.0.6"
@@ -16,8 +16,8 @@
         "vite": "^4.4.8"
       },
       "peerDependencies": {
-        "@dytesdk/ui-kit": ">=2.0.4",
-        "@dytesdk/web-core": ">=2.1.2"
+        "@dytesdk/ui-kit": ">=2.2.0",
+        "@dytesdk/web-core": ">=2.3.0"
       }
     },
     "node_modules/@babel/runtime": {
@@ -32,7 +32,9 @@
       }
     },
     "node_modules/@dytesdk/ui-kit": {
-      "version": "2.0.6",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@dytesdk/ui-kit/-/ui-kit-2.2.0.tgz",
+      "integrity": "sha512-ILuhoVQw45T5wis54V7+KiIMuKRfyBYpKrgYaOooccsudpNBHh+yoMwZuXyU1lodJJKsZ2ICNUT1WS/iNwaRyA==",
       "peer": true
     },
     "node_modules/@dytesdk/video-background-transformer": {
@@ -41,7 +43,9 @@
       "integrity": "sha512-lJ/D/jRMOxCoq+PLmDHd+bsMQT1UmwBJyw2Hdk/TSIpOEpOFANQtO9aqDN1MteAerwKVdsvasjp65q8kbxOssw=="
     },
     "node_modules/@dytesdk/web-core": {
-      "version": "2.1.10",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@dytesdk/web-core/-/web-core-2.3.0.tgz",
+      "integrity": "sha512-oQhMA/dak56ovLIy/6uwI7CxDGbzmK7ZAvBTLY6S5JRPjmv8GsZiCUNHmXEtPu+AkoULzrQEkSs2/3o6Gugumw==",
       "peer": true,
       "dependencies": {
         "@protobuf-ts/runtime": "^2.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dytesdk/ui-kit-addons",
-  "version": "3.1.8",
+  "version": "4.0.0",
   "description": "A collection of Dyte UI-kit addons",
   "type": "module",
   "exports": {
@@ -117,8 +117,8 @@
   },
   "main": "index.js",
   "peerDependencies": {
-    "@dytesdk/ui-kit": ">=2.0.4",
-    "@dytesdk/web-core": ">=2.1.2"
+    "@dytesdk/ui-kit": ">=2.2.0",
+    "@dytesdk/web-core": ">=2.3.0"
   },
   "devDependencies": {
     "typescript": "^5.2.2",

--- a/src/video-background/BackgroundChanger.ts
+++ b/src/video-background/BackgroundChanger.ts
@@ -125,6 +125,10 @@ img {
   border: 2px solid rgb(var(--dyte-colors-background-800, 26 26 26));
 }
 
+.highlighted {
+    border: 2px solid rgb(var(--dyte-colors-brand-500, 26 26 26));
+}
+
 .image-container:hover {
     border: 2px solid rgb(var(--dyte-colors-brand-500, 26 26 26));
 }
@@ -212,11 +216,11 @@ export class BackgroundChanger extends HTMLElement {
 
     set isVideoBackgroundBeingApplied(isBeingApplied: boolean){
         this._isVideoBackgroundBeingApplied = isBeingApplied;
-        this.shadow.querySelectorAll('.js-image-row')?.forEach((imageRow: HTMLImageElement) => {
+        this.shadow.querySelectorAll('.js-middleware-action-element')?.forEach((middlewareActionElement: HTMLElement) => {
             if(isBeingApplied){
-                imageRow.classList.add('video-background-update-ongoing');
+                middlewareActionElement.classList.add('video-background-update-ongoing');
             } else {
-                imageRow.classList.remove('video-background-update-ongoing');
+                middlewareActionElement.classList.remove('video-background-update-ongoing');
             }
         });
     }
@@ -225,7 +229,7 @@ export class BackgroundChanger extends HTMLElement {
         return this._isVideoBackgroundBeingApplied;
     }
 
-    set onChange(change: () => void) {
+    set onChange(change: (mode: BackgroundMode, imageURL?: string, imageElement?: HTMLImageElement) => void) {
         this._onchange = change;
         this.updatedProps();
     }
@@ -287,7 +291,7 @@ export class BackgroundChanger extends HTMLElement {
         if (!this._images || this._images.length === 0) return imageRows;
         this._images.map((image, i) => {
             const row = document.createElement("img");
-            row.setAttribute("class", "container image-container js-image-row js-image-loading");
+            row.setAttribute("class", "container image-container js-middleware-action-element js-image-middleware js-image-loading");
             row.setAttribute("key", i.toString());
             row.setAttribute("crossOrigin", 'anonymous');
             row.setAttribute("src", image);
@@ -314,11 +318,15 @@ export class BackgroundChanger extends HTMLElement {
             container.classList.add('video-background-update-ongoing');
         }
         if (type === "blur") {
+            container.classList.add("js-middleware-action-element");
+            container.classList.add("js-blur-middleware");
             box.innerHTML = BLUR_ICON;
             box.addEventListener("click", () => {
                 this._onchange("blur");
             });
         } else {
+            container.classList.add("js-middleware-action-element");
+            container.classList.add("js-no-middleware");
             box.innerHTML = NONE_ICON;
             box.addEventListener("click", () => {
                 this._onchange("none");
@@ -380,6 +388,33 @@ export class BackgroundChanger extends HTMLElement {
 
     attributeChangedCallback() {
         this.create();
+    }
+
+    highlightSelectedMiddleware(currentBackgroundMode: BackgroundMode, currentBackgroundURL: string) {
+        if(currentBackgroundMode === 'blur'){
+            this.shadow.querySelectorAll('.js-middleware-action-element').forEach((element: HTMLElement) => {
+                element.classList.remove('highlighted');
+            });
+            this.shadow.querySelectorAll('.js-blur-middleware').forEach((element: HTMLElement) => {
+                element.classList.add('highlighted');
+            });
+        } else if(currentBackgroundMode === 'virtual'){
+            this.shadow.querySelectorAll('.js-middleware-action-element').forEach((element: HTMLElement) => {
+                element.classList.remove('highlighted');
+            });
+            this.shadow.querySelectorAll('.js-image-middleware').forEach((element: HTMLElement) => {
+                if(element.getAttribute('src') === currentBackgroundURL){
+                    element.classList.add('highlighted');
+                }
+            });
+        } else if(currentBackgroundMode === 'none'){
+            this.shadow.querySelectorAll('.js-middleware-action-element').forEach((element: HTMLElement) => {
+                element.classList.remove('highlighted');
+            });
+            this.shadow.querySelectorAll('.js-no-middleware').forEach((element: HTMLElement) => {
+                element.classList.add('highlighted');
+            });
+        }
     }
 
     connectedCallback() {

--- a/src/video-background/index.ts
+++ b/src/video-background/index.ts
@@ -227,7 +227,21 @@ export default class VideoBGAddon {
     }
 
     async removeCurrentMiddleware({skipHighlightingTransientRemoval = false}: {skipHighlightingTransientRemoval: boolean}) {
-        await this.meeting.self.removeVideoMiddleware(this.middleware);
+        /**
+         * NOTE(ravindra-dyte):
+         * 
+         * Even though we should only be removing the current middleware,
+         * for a breakout room, if meeting has changed and for the middleware was carry forwarded,
+         * It could be that the middleware is part of meeting.self but not the ui-kit-addons instance.
+         * 
+         * Since most clients, when they use middlewares with disablePerFrameCanvasRendering as true, they use just this middleware alone,
+         * and for their custom needs, use meeting.self.videoTrack,
+         * therefore going with an assumption that removing all video middlewares won't impact anything.
+         * 
+         * In future releases, this assumption will be removed.
+         */
+        // await this.meeting.self.removeVideoMiddleware(this.middleware);
+        await this.meeting.self.removeAllVideoMiddlewares();
         this.middleware = null;
         this.currentBackgroundMode = 'none';
         this.currentBackgroundURL = null;

--- a/src/video-background/index.ts
+++ b/src/video-background/index.ts
@@ -54,7 +54,7 @@ export default class VideoBGAddon {
     currentBackgroundURL:  string | null = null;
     videoBackgroundChanger: BackgroundChanger | null = null;
 
-    constructor(args?: VideoBGAddonArgs) {
+    private constructor(args?: VideoBGAddonArgs) {
         this.images = args?.images ?? [];
         this.meeting = args?.meeting;
         this.modes =

--- a/src/video-background/index.ts
+++ b/src/video-background/index.ts
@@ -218,9 +218,8 @@ export default class VideoBGAddon {
 
         this.videoBackgroundChanger['isVideoBackgroundUpdateOngoing'] =  true;
 
-        if (this.middleware) {
-            await this.removeCurrentMiddleware();
-        }
+        await this.removeCurrentMiddleware();
+
         /**
          * Internally we are passing images as dataURL to not refetch the image in case data cache is disabled,
          * which could be the case with Dev tools being opened. So, we are checking if the imageURL is not a dataURL
@@ -270,9 +269,8 @@ export default class VideoBGAddon {
 
         this.videoBackgroundChanger['isVideoBackgroundUpdateOngoing'] =  true;
 
-        if (this.middleware) {
-            await this.removeCurrentMiddleware();
-        }
+        await this.removeCurrentMiddleware();
+        
         this.middleware =
             await this.transform.createBackgroundBlurVideoMiddleware(this.blurStrength);
         await this.meeting.self.addVideoMiddleware(this.middleware);

--- a/src/video-background/index.ts
+++ b/src/video-background/index.ts
@@ -116,10 +116,10 @@ export default class VideoBGAddon {
             }
             changer['isVideoBackgroundBeingApplied'] =  true;
             if (mode === "blur") {
-                await videoBGAddon.addVideoBlurBackground();
+                await videoBGAddon.applyBlurBackground();
             } else if (mode === "virtual" && imageURL) {
                 const imageAsDataURL = videoBGAddon.getImageDataURLFromImage(imageElement);
-                await videoBGAddon.addVideoVirtualBackground(imageURL, imageAsDataURL);
+                await videoBGAddon.applyVirtualBackground(imageURL, imageAsDataURL);
             } else if (mode === "none") {
                 await videoBGAddon.removeCurrentMiddleware({skipHighlightingTransientRemoval: false});
             }
@@ -141,7 +141,7 @@ export default class VideoBGAddon {
         return videoBGAddon;
     }
 
-    getImageDataURLFromImage(img: HTMLImageElement) {
+    private getImageDataURLFromImage(img: HTMLImageElement) {
         const canvas = document.createElement("canvas");
         canvas.width = img.naturalWidth;
         canvas.height = img.naturalHeight;
@@ -150,7 +150,7 @@ export default class VideoBGAddon {
         return canvas.toDataURL();
     }
 
-    async getRandomImages(count: number) {
+    private async getRandomImages(count: number) {
         let images = [
             'https://assets.dyte.io/backgrounds/bg_1.jpg',
             'https://assets.dyte.io/backgrounds/bg_2.jpg',
@@ -179,7 +179,7 @@ export default class VideoBGAddon {
         });
     }
 
-    async addVideoVirtualBackground(imageURL: string, imageAsDataURL?: string) {
+    public async applyVirtualBackground(imageURL: string, imageAsDataURL?: string) {
         if (!DyteVideoBackgroundTransformer.isSupported()) return;
 
         if (this.middleware) {
@@ -212,7 +212,7 @@ export default class VideoBGAddon {
         this.videoBackgroundChanger.highlightSelectedMiddleware(this.currentBackgroundMode, this.currentBackgroundURL);
     }
 
-    async addVideoBlurBackground() {
+    public async applyBlurBackground() {
         if (!DyteVideoBackgroundTransformer.isSupported()) return;
 
         if (this.middleware) {
@@ -226,7 +226,7 @@ export default class VideoBGAddon {
         this.videoBackgroundChanger.highlightSelectedMiddleware(this.currentBackgroundMode, this.currentBackgroundURL);
     }
 
-    async removeCurrentMiddleware({skipHighlightingTransientRemoval = false}: {skipHighlightingTransientRemoval: boolean}) {
+    private async removeCurrentMiddleware({skipHighlightingTransientRemoval = false}: {skipHighlightingTransientRemoval: boolean}) {
         /**
          * NOTE(ravindra-dyte):
          * 
@@ -250,27 +250,17 @@ export default class VideoBGAddon {
         }
     }
 
-    async removeVideoVirtualBackground() {
-        if(this.currentBackgroundMode === 'virtual'){
+    public async removeBackground() {
             await this.removeCurrentMiddleware({
                 skipHighlightingTransientRemoval: false,
             });
-        }
     }
 
-    async removeVideoBlurBackground() {
-        if(this.currentBackgroundMode === 'blur'){
-            await this.removeCurrentMiddleware({
-                skipHighlightingTransientRemoval: false
-            });
-        }
+    public async unregister() {
+        await this.removeBackground();
     }
 
-    async unregister() {
-        await this.removeVideoVirtualBackground();
-    }
-
-    addControlBarButton(selector: any, attributes: { [key: string]: any }) {
+    private addControlBarButton(selector: any, attributes: { [key: string]: any }) {
         selector.add("dyte-controlbar-button", {
             id: "effects",
             label: this.buttonLabel,
@@ -293,7 +283,7 @@ export default class VideoBGAddon {
         });
     }
 
-    register(config: UIConfig, _meeting: Meeting, getBuilder: (c: UIConfig) => DyteUIBuilder) {
+    public register(config: UIConfig, _meeting: Meeting, getBuilder: (c: UIConfig) => DyteUIBuilder) {
         if (!DyteVideoBackgroundTransformer.isSupported()) return config;
 
         // Add buttons with config


### PR DESCRIPTION
1. Added selected middleware highlighter.
2. Moving the heavy loading to initialization rather than register to speed things up & manageable.
3. Made the initialisation part similar to Host Chat/Camera/Mic control.
4. Rather than relying on third party services that can fail (AND ARE CURRENTLY FAILING), using Dyte backgrounds to ensure future support. This currently limits random middlewares to 7. In future, we can add more backgrounds.
5. Users can now add or remove middlewares programmatically.
```
await videoBackground.addVideoVirtualBackground('https://images.unsplash.com/photo-1496715976403-7e36dc43f17b?q=80&w=2848&auto=format&fit=crop&ixlib=rb-4.0.3');
await videoBackground.addVideoBlurBackground();
await videoBackground.removeVideoVirtualBackground();
await videoBackground.removeVideoBlurBackground();
```
              