### PR TITLE
fix(video-background): in case of mulitple meeting on same page, states were mixed up

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cloudflare/realtimekit-ui-addons",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cloudflare/realtimekit-ui-addons",
-      "version": "0.0.3",
+      "version": "0.0.4",
       "license": "UNLICENSED",
       "dependencies": {
         "@cloudflare/realtimekit-virtual-background": "0.0.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudflare/realtimekit-ui-addons",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "A collection of Cloudflare RealtimeKit UI addons",
   "type": "module",
   "exports": {

--- a/src/video-background/index.ts
+++ b/src/video-background/index.ts
@@ -128,11 +128,11 @@ export default class VideoBGAddon {
         //    postProcessingConfig: videoBGAddon.postProcessingConfig || {},
         // });
 
-        const elements = document.getElementsByTagName("rtk-background-changer")
+        let existingBackgroundChangerContainer = videoBGAddon.selector ? document.querySelector(videoBGAddon.selector) : document;
+        const existingBackgroundChanger = existingBackgroundChangerContainer?.querySelector("rtk-background-changer");
         
-        if (elements[0]) {
-            // remove rtk-background-changer
-            elements[0].remove();
+        if (existingBackgroundChanger) {
+            existingBackgroundChanger.remove();
         }
 
         const changer = document.createElement("rtk-background-changer") as BackgroundChanger;
@@ -384,13 +384,12 @@ export default class VideoBGAddon {
             icon: this.buttonIcon ?? defaultIcon,
             // @ts-ignore
             onClick: () => {
-                const changer = document.querySelector(
-                    "rtk-background-changer"
-                );
-                if (changer) {
+                let backgroundChangerContainer = this.selector ? document.querySelector(this.selector) : document;
+                const backgroundChanger = backgroundChangerContainer?.querySelector("rtk-background-changer");
+                if (backgroundChanger) {
                     const isOpen =
-                        changer?.getAttribute("data-open") === "true";
-                    changer.setAttribute(
+                    backgroundChanger?.getAttribute("data-open") === "true";
+                    backgroundChanger.setAttribute(
                         "data-open",
                         isOpen ? "false" : "true"
                     );


### PR DESCRIPTION
RealtimeKit is undergoing changes to support concurrent multiple meetings on the same page. We are also rolling out Effects supports for such a use case.

Previously code was designed and tested only for a single meeting on a page at any time.

I have fixed the code to support multiple meetings now with their isolated video background transformer.